### PR TITLE
Potential fix for code scanning alert no. 2: Information exposure through an exception

### DIFF
--- a/app/routes/schema_scoring_routes.py
+++ b/app/routes/schema_scoring_routes.py
@@ -50,8 +50,9 @@ def score_schema():
         return jsonify(scores), 200
 
     except Exception as e: # pylint: disable=broad-exception-caught
+        app.logger.error(f"An error occurred: {str(e)}")
         return jsonify({
             'error': 'Internal Server Error',
-            'message': str(e)
+            'message': 'An internal error has occurred. Please try again later.'
         }), 500
 


### PR DESCRIPTION
Potential fix for [https://github.com/the-data-omni/schema_scoring_api/security/code-scanning/2](https://github.com/the-data-omni/schema_scoring_api/security/code-scanning/2)

To fix the problem, we need to ensure that detailed exception messages are not exposed to the end user. Instead, we should log the detailed error message on the server and return a generic error message to the user. This approach maintains the security of the application while still allowing developers to debug issues using the server logs.

1. Modify the exception handling block to log the detailed error message on the server.
2. Return a generic error message to the user.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
